### PR TITLE
configuration: more verbose logging for ofborg builders

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -247,6 +247,7 @@ in makeNetboot {
             git config --global user.email "graham+cofborg@grahamc.com"
             git config --global user.name "GrahamCOfBorg"
             export RUST_BACKTRACE=1
+            export RUST_LOG=trace
 
             ${ofborg}/bin/builder /persist/ofborg/config-${id}.json
           '';


### PR DESCRIPTION
<!-- If you're not requesting access, delete the following: -->

- [ ] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [ ] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [ ] I know when I can't trust the builder, as explained in the README
