### PR TITLE
Make example config in the readme ready for building NixOS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ First, put this in your `configuration.nix`:
         sshKey = "/root/a-private-key";
         sshUser = "your-user-name";
         system = "aarch64-linux";
-        supportedFeatures = [ "big-parallel" ];
+        supportedFeatures = [ "big-parallel" "kvm" "nixos-test" ];
       }
     ];
   };


### PR DESCRIPTION
This way people can build NixOS tests right from the start, and the build box seems to be able to do so.

<!-- If you're not requesting access, delete the following: -->

- [ ] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [ ] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [ ] I know when I can't trust the builder, as explained in the README
