### PR TITLE
users.nix: add w4tsn

### DIFF
--- a/keys/w4tsn
+++ b/keys/w4tsn
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII6B42kIwpEyFWFxEanCNbTLp3cTjppzlEjCwyxQMNUa w4tsn@scrappy

--- a/users.nix
+++ b/users.nix
@@ -506,6 +506,11 @@ let
       trusted = true;
       keys = ./keys/zowoq;
     };
+
+    w4tsn = {
+      trusted = true;
+      keys = ./keys/w4tsn;
+    }
   };
 
   ifAttr = key: default: result: opts:


### PR DESCRIPTION
- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
