### PR TITLE
users: add anthonyroussel

### DIFF
--- a/keys/anthonyroussel
+++ b/keys/anthonyroussel
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPSkqEEWsQwJ/3BM15TQMkMMfd/hitE505BBxP3KAYn8 anthonyroussel@aarch64-build-box

--- a/users.nix
+++ b/users.nix
@@ -51,6 +51,11 @@ let
       keys = ./keys/angerman;
     };
 
+    anthonyroussel = {
+      trusted = true;
+      keys = ./keys/anthonyroussel;
+    };
+
     artturin = {
       trusted = true;
       keys = ./keys/artturin;


### PR DESCRIPTION
Hello!

I [contribute regularly to nixpkgs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Aanthonyroussel), but I don't own any aarch64 builder to test the builds of the packages I add to nixpkgs.

I would like to use this build box to test that my changes build fine on aarch64 platform, and help improve ARM support for nixpkgs :)

Is it possible to be added to the build box, please?

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
