### PR TITLE
Add SebTM to trusted users

### DIFF
--- a/keys/sebtm
+++ b/keys/sebtm
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICk8HA/hrBTY/LeXV6gARww046iR9AAq83xk75VC3Z/0 mail@sebastian-sellmeier.de

--- a/users.nix
+++ b/users.nix
@@ -439,6 +439,11 @@ let
       keys = ./keys/samueldr;
     };
 
+    sebtm = {
+      trusted = true;
+      keys = ./keys/sebtm;
+    };
+
     solene = {
       trusted = true;
       keys = ./keys/solene;


### PR DESCRIPTION
- [X] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [X] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [X] I know when I can't trust the builder, as explained in the README

I'm nixpkgs/home-manager maintainer, recently trying to use/help out with https://github.com/tstat/raspberry-pi-nix and attempts to build/improve NixOS on the BPI-R3 why I would like to request access to the shared aarch64-builder.