### PR TITLE
Add btop and htop to systemPackages

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -118,7 +118,9 @@
       ];
 
       environment.systemPackages = [
+        pkgs.btop
         pkgs.git
+        pkgs.htop
       ];
 
       systemd.services.nix-daemon = {


### PR DESCRIPTION
For easier monitoring of system resources I propose to add [btop](https://github.com/aristocratos/btop) and `htop` to the system packages.

- [x] I have read the entire README https://github.com/nix-community/aarch64-build-box
- [x] I completely understood the README https://github.com/nix-community/aarch64-build-box
- [x] I know when I can't trust the builder, as explained in the README
